### PR TITLE
feat: add pipeline glue layer for end-to-end interpretability workflows

### DIFF
--- a/examples/full_pipeline_demo.py
+++ b/examples/full_pipeline_demo.py
@@ -1,0 +1,179 @@
+"""
+End-to-end interpretability pipeline demo using GPT-2.
+
+Demonstrates the full flow: model → logit lens → activations → probe →
+SAE → circuit discovery → visualization-ready outputs.
+
+Usage:
+    python examples/full_pipeline_demo.py
+
+Requires: torch, transformers, scikit-learn
+"""
+
+from glassboxllms.pipeline import (
+    extract_activations,
+    train_sae_on_model,
+    train_probe_on_model,
+    discover_circuit,
+    run_logit_lens,
+)
+
+MODEL_NAME = "gpt2"
+TARGET_LAYER = "transformer.h.5"
+
+
+def main():
+    # ----------------------------------------------------------------
+    # 1. Logit Lens — see what the model predicts at each layer
+    # ----------------------------------------------------------------
+    print("=" * 60)
+    print("Step 1: Logit Lens Analysis")
+    print("=" * 60)
+
+    logit_results = run_logit_lens(MODEL_NAME, "The capital of France is", top_k=5)
+
+    print(f"Tokens: {logit_results['tokens']}")
+    print(f"Logit lens data shape: {logit_results['logit_lens_data'].shape}")
+    print(f"Top predictions at final layer, last token: {logit_results['top_k_tokens'][-1][-1]}")
+
+    # The logit_lens_data can be fed directly to plot_logit_lens:
+    #   from glassboxllms.visualization import plot_logit_lens
+    #   fig = plot_logit_lens(logit_results["logit_lens_data"], logit_results["tokens"],
+    #                         top_k_tokens=logit_results["top_k_tokens"])
+    #   fig.savefig("logit_lens.png")
+
+    # ----------------------------------------------------------------
+    # 2. Extract Activations — raw hidden states from a layer
+    # ----------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("Step 2: Extract Activations")
+    print("=" * 60)
+
+    texts = [
+        "The cat sat on the mat.",
+        "Machine learning is transforming science.",
+        "The president gave a speech yesterday.",
+    ]
+
+    acts = extract_activations(MODEL_NAME, texts, [TARGET_LAYER], return_type="torch")
+    print(f"Activation shape for {TARGET_LAYER}: {acts[TARGET_LAYER].shape}")
+
+    # Also works with numpy output
+    acts_np = extract_activations(MODEL_NAME, texts, [TARGET_LAYER], return_type="numpy")
+    print(f"Numpy activation shape: {acts_np[TARGET_LAYER].shape}")
+
+    # ----------------------------------------------------------------
+    # 3. Train Linear Probe — test if sentiment is encoded
+    # ----------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("Step 3: Train Linear Probe")
+    print("=" * 60)
+
+    positive_texts = [
+        "I love this movie, it was fantastic!",
+        "This is wonderful and amazing.",
+        "Great job, I'm so happy with the results.",
+        "The food was delicious and the service excellent.",
+        "What a beautiful day, everything is perfect!",
+    ]
+
+    negative_texts = [
+        "I hate this, it was terrible.",
+        "This is awful and disappointing.",
+        "Terrible work, I'm very upset.",
+        "The food was disgusting and the service horrible.",
+        "What an ugly mess, nothing works right.",
+    ]
+
+    probe, direction = train_probe_on_model(
+        MODEL_NAME,
+        positive_texts,
+        negative_texts,
+        layer=TARGET_LAYER,
+    )
+    print(f"Probe fitted: {probe.is_fitted}")
+    print(f"Direction vector shape: {direction.shape}")
+    print(f"Direction vector norm: {float(sum(direction**2)**0.5):.4f}")
+
+    # ----------------------------------------------------------------
+    # 4. Train SAE — extract sparse features from activations
+    # ----------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("Step 4: Train Sparse Autoencoder")
+    print("=" * 60)
+
+    training_texts = [
+        "The quick brown fox jumps over the lazy dog.",
+        "Scientists discovered a new species of deep-sea fish.",
+        "The stock market reached an all-time high today.",
+        "She played a beautiful melody on the piano.",
+        "The algorithm processes data in logarithmic time.",
+        "Rain is expected throughout the weekend.",
+        "The team won the championship in overtime.",
+        "Quantum computers can solve certain problems faster.",
+    ]
+
+    sae, feature_set = train_sae_on_model(
+        MODEL_NAME,
+        training_texts,
+        layer=TARGET_LAYER,
+        feature_dim=512,
+        k=32,
+        n_epochs=3,
+        batch_size=16,
+    )
+    print(f"\nSAE: {sae}")
+    print(f"FeatureSet: {feature_set}")
+    print(f"Number of features: {len(feature_set)}")
+
+    # Access individual features
+    feature_0 = feature_set[0]
+    print(f"Feature 0 decoder vector shape: {feature_0.decoder_vector.shape}")
+
+    # ----------------------------------------------------------------
+    # 5. Discover Circuit — find important components
+    # ----------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("Step 5: Circuit Discovery")
+    print("=" * 60)
+
+    def simple_metric(output):
+        """Measure the norm of the output as a simple metric."""
+        if hasattr(output, "last_hidden_state"):
+            return output.last_hidden_state[0, -1].norm()
+        return output[0, -1].norm()
+
+    # Use a subset of layers for demo speed
+    demo_layers = [f"transformer.h.{i}" for i in range(6)]
+
+    graph = discover_circuit(
+        MODEL_NAME,
+        text="The capital of France is",
+        metric_fn=simple_metric,
+        layers=demo_layers,
+        strategy="zero",
+    )
+    print(f"Circuit graph: {graph}")
+    print(f"Graph summary: {graph.summary()}")
+
+    # The graph can be fed to visualization:
+    #   from glassboxllms.visualization import plot_circuit_graph
+    #   fig = plot_circuit_graph(graph)
+    #   fig.savefig("circuit.png")
+
+    # ----------------------------------------------------------------
+    # Summary
+    # ----------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("Pipeline Complete!")
+    print("=" * 60)
+    print("All pipeline functions work end-to-end.")
+    print("Results can be passed directly to visualization functions:")
+    print("  - plot_logit_lens(logit_results['logit_lens_data'], ...)")
+    print("  - plot_circuit_graph(graph)")
+    print("  - plot_sae_training_curves(stats)")
+    print("  - plot_probe_accuracy(probe_result)")
+
+
+if __name__ == "__main__":
+    main()

--- a/glassboxllms/features/trainer.py
+++ b/glassboxllms/features/trainer.py
@@ -13,11 +13,12 @@ Implements modern training techniques:
 import torch
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
-from typing import Dict, Any, List, Optional, Callable, Literal
+from typing import Dict, Any, List, Optional, Callable, Literal, Union
 from dataclasses import dataclass, field
 import time
 
 from .sae import SparseAutoencoder
+from .feature_set import FeatureSet
 from .utils import (
     calc_explained_variance,
     calc_mse_loss,
@@ -500,6 +501,41 @@ class SAETrainer:
                 for i in range(len(l0_per_feature))
             ],
         }
+
+    def get_feature_set(
+        self,
+        model_name: str = "unknown",
+        layer: Union[str, int] = 0,
+    ) -> FeatureSet:
+        """
+        Convert trained SAE into a FeatureSet object.
+
+        Extracts decoder/encoder weights and training statistics into a
+        FeatureSet for downstream analysis and serialization.
+
+        Args:
+            model_name: Name of the source model (for metadata).
+            layer: Layer identifier (for metadata).
+
+        Returns:
+            FeatureSet containing the trained SAE's features.
+        """
+        stats = self.get_stats()
+        per_feature_stats = stats.pop("per_feature_stats", [])
+
+        # Enrich config with model/layer info
+        config = self.sae.get_config()
+        config["model_name"] = model_name
+        config["layer"] = layer
+
+        return FeatureSet(
+            config=config,
+            stats=stats,
+            W_dec=self.sae.W_dec.data.clone(),
+            W_enc=self.sae.W_enc.data.clone() if hasattr(self.sae, "W_enc") and self.sae.W_enc is not None else None,
+            feature_stats=per_feature_stats,
+            metadata={"source": "SAETrainer.get_feature_set"},
+        )
 
     def evaluate(self, dataloader: DataLoader) -> Dict[str, float]:
         """

--- a/glassboxllms/pipeline.py
+++ b/glassboxllms/pipeline.py
@@ -1,0 +1,444 @@
+"""
+Pipeline glue layer for end-to-end interpretability workflows.
+
+Provides high-level functions that chain model → activations → SAE/probes →
+features → visualization, handling type conversions and boilerplate automatically.
+
+Users can go from model → results in a few lines:
+
+    >>> from glassboxllms.pipeline import train_sae_on_model, train_probe_on_model
+    >>> sae, features = train_sae_on_model("gpt2", texts, layer=5)
+    >>> probe, direction = train_probe_on_model("gpt2", pos_texts, neg_texts, layer=5)
+"""
+
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+from .features import SparseAutoencoder, SAETrainer, FeatureSet
+from .primitives.probes.linear import LinearProbe
+from .analysis.circuits.graph import CircuitGraph
+from .analysis.circuits.node import NodeType, EdgeType
+
+
+def _to_torch(x: Union[np.ndarray, torch.Tensor], dtype: torch.dtype = torch.float32) -> torch.Tensor:
+    """Convert numpy array to torch tensor if needed."""
+    if isinstance(x, np.ndarray):
+        return torch.from_numpy(x).to(dtype)
+    return x.to(dtype)
+
+
+def _to_numpy(x: Union[np.ndarray, torch.Tensor]) -> np.ndarray:
+    """Convert torch tensor to numpy array if needed."""
+    if isinstance(x, torch.Tensor):
+        return x.detach().cpu().numpy()
+    return np.asarray(x)
+
+
+def _load_model(model_name: str) -> Any:
+    """Load a HuggingFace model wrapped in ModelWrapper."""
+    from .models.huggingface import TransformersModelWrapper
+
+    class _ConcreteWrapper(TransformersModelWrapper):
+        """Concrete wrapper since TransformersModelWrapper is abstract."""
+        pass
+
+    return _ConcreteWrapper(model_name)
+
+
+def extract_activations(
+    model_name: str,
+    texts: List[str],
+    layers: List[str],
+    return_type: str = "torch",
+    model: Optional[Any] = None,
+) -> Dict[str, Union[torch.Tensor, np.ndarray]]:
+    """
+    Extract activations from a model at specified layers.
+
+    Wraps ModelWrapper.get_activations() with automatic type handling.
+
+    Args:
+        model_name: HuggingFace model name (e.g., "gpt2").
+        texts: Input texts to extract activations for.
+        layers: Layer identifiers to extract from.
+        return_type: "torch" or "numpy" — output format.
+        model: Optional pre-loaded ModelWrapper (avoids reloading).
+
+    Returns:
+        Dict mapping layer names to activation tensors/arrays.
+        Shape: (batch_size, seq_len, hidden_dim) per layer.
+    """
+    if model is None:
+        model = _load_model(model_name)
+
+    # Always extract as torch for internal consistency
+    raw = model.get_activations(texts, layers, return_type="torch")
+
+    result = {}
+    for layer_name, acts in raw.items():
+        if return_type == "numpy":
+            result[layer_name] = _to_numpy(acts)
+        else:
+            result[layer_name] = _to_torch(acts)
+
+    return result
+
+
+def train_sae_on_model(
+    model_name: str,
+    texts: List[str],
+    layer: str,
+    feature_dim: int = 2048,
+    k: int = 64,
+    n_epochs: int = 5,
+    batch_size: int = 32,
+    lr: float = 1e-4,
+    device: str = "cpu",
+    model: Optional[Any] = None,
+) -> Tuple[SparseAutoencoder, FeatureSet]:
+    """
+    Train a Sparse Autoencoder on model activations end-to-end.
+
+    Extracts activations → creates DataLoader → trains SAE → returns FeatureSet.
+
+    Args:
+        model_name: HuggingFace model name (e.g., "gpt2").
+        texts: Training texts.
+        layer: Layer to extract activations from.
+        feature_dim: Number of SAE features.
+        k: Top-k sparsity parameter.
+        n_epochs: Training epochs.
+        batch_size: Training batch size.
+        lr: Learning rate.
+        device: Device for training.
+        model: Optional pre-loaded ModelWrapper.
+
+    Returns:
+        Tuple of (trained SparseAutoencoder, FeatureSet).
+    """
+    # Extract activations
+    acts_dict = extract_activations(
+        model_name, texts, [layer], return_type="torch", model=model
+    )
+    activations = acts_dict[layer]  # (batch, seq_len, hidden_dim)
+
+    # Flatten to 2D: (batch * seq_len, hidden_dim)
+    if activations.ndim == 3:
+        activations = activations.reshape(-1, activations.shape[-1])
+    activations = activations.to(torch.float32)
+
+    input_dim = activations.shape[-1]
+
+    # Create DataLoader
+    dataset = TensorDataset(activations)
+    dataloader = DataLoader(dataset, batch_size=batch_size, shuffle=True)
+
+    # Create and train SAE
+    sae = SparseAutoencoder(
+        input_dim=input_dim,
+        feature_dim=feature_dim,
+        k=k,
+        device=device,
+    )
+    sae.initialize_geometric_median(activations[:min(len(activations), 10000)])
+
+    optimizer = torch.optim.Adam(sae.parameters(), lr=lr)
+    trainer = SAETrainer(sae, dataloader, optimizer=optimizer, device=device)
+    stats = trainer.train(n_epochs=n_epochs)
+
+    # Convert to FeatureSet
+    feature_set = trainer.get_feature_set(model_name=model_name, layer=layer)
+
+    return sae, feature_set
+
+
+def train_probe_on_model(
+    model_name: str,
+    positive_texts: List[str],
+    negative_texts: List[str],
+    layer: str,
+    probe_type: str = "logistic",
+    model: Optional[Any] = None,
+) -> Tuple[LinearProbe, np.ndarray]:
+    """
+    Train a linear probe on model activations end-to-end.
+
+    Extracts activations for positive/negative examples → trains probe →
+    returns probe and learned direction vector.
+
+    Args:
+        model_name: HuggingFace model name (e.g., "gpt2").
+        positive_texts: Texts representing the positive concept.
+        negative_texts: Texts representing the negative concept.
+        layer: Layer to extract activations from.
+        probe_type: Type of probe ("logistic", "cav", etc.).
+        model: Optional pre-loaded ModelWrapper.
+
+    Returns:
+        Tuple of (trained LinearProbe, direction vector as numpy array).
+    """
+    if model is None:
+        model = _load_model(model_name)
+
+    # Extract activations for both sets
+    all_texts = positive_texts + negative_texts
+    acts_dict = extract_activations(
+        model_name, all_texts, [layer], return_type="numpy", model=model
+    )
+    activations = acts_dict[layer]  # (batch, seq_len, hidden_dim)
+
+    # Average over sequence length if 3D
+    if activations.ndim == 3:
+        activations = activations.mean(axis=1)
+
+    # Create labels: 1 for positive, 0 for negative
+    labels = np.array(
+        [1] * len(positive_texts) + [0] * len(negative_texts),
+        dtype=np.int64,
+    )
+
+    # Train probe
+    probe = LinearProbe(
+        layer=layer,
+        direction=f"{probe_type}_probe",
+        model_type=probe_type,
+    )
+    probe.fit(activations, labels)
+
+    direction = probe.get_direction()
+
+    return probe, direction
+
+
+def discover_circuit(
+    model_name: str,
+    text: str,
+    metric_fn: Callable,
+    layers: Optional[List[str]] = None,
+    corrupted_text: Optional[str] = None,
+    strategy: str = "zero",
+    model: Optional[Any] = None,
+) -> CircuitGraph:
+    """
+    Discover a circuit by scanning layers with CausalScrubber.
+
+    Runs ablation at each layer, measures metric impact, and populates
+    a CircuitGraph with the results.
+
+    Args:
+        model_name: HuggingFace model name (e.g., "gpt2").
+        text: Clean input text.
+        metric_fn: Function(model_output) -> scalar measuring behavior.
+        layers: Layers to scan (defaults to all model layers).
+        corrupted_text: Optional corrupted input for patch strategy.
+        strategy: Ablation strategy ("zero", "mean", "random", "patch").
+        model: Optional pre-loaded ModelWrapper.
+
+    Returns:
+        CircuitGraph populated with nodes for each scanned layer and
+        edges weighted by metric impact.
+    """
+    from .analysis.circuits.causal_scrubbing import CausalScrubber
+    from .primitives.probes.activation_store import ActivationStore
+
+    if model is None:
+        model = _load_model(model_name)
+
+    wrapper_model = model.model
+    if layers is None:
+        layers = model.layer_names
+
+    # Tokenize inputs
+    tokens = model.tokenizer(text, return_tensors="pt", padding=True, truncation=True)
+    clean_input = tokens["input_ids"]
+
+    corrupted_input = None
+    if corrupted_text is not None:
+        corrupted_tokens = model.tokenizer(
+            corrupted_text, return_tensors="pt", padding=True, truncation=True
+        )
+        corrupted_input = corrupted_tokens["input_ids"]
+
+    # Get baseline metric
+    with torch.no_grad():
+        baseline_output = wrapper_model(clean_input)
+        if hasattr(baseline_output, "logits"):
+            baseline_metric = metric_fn(baseline_output.logits)
+        elif hasattr(baseline_output, "last_hidden_state"):
+            baseline_metric = metric_fn(baseline_output.last_hidden_state)
+        else:
+            baseline_metric = metric_fn(baseline_output)
+    baseline_val = float(baseline_metric) if isinstance(baseline_metric, torch.Tensor) else float(baseline_metric)
+
+    # Build circuit graph
+    graph = CircuitGraph(
+        model=model_name,
+        name=f"circuit_scan_{model_name}",
+        metadata={
+            "strategy": strategy,
+            "baseline_metric": baseline_val,
+            "text": text,
+        },
+    )
+
+    # Add input node
+    graph.add_node("input", node_type=NodeType.EMBEDDING, layer=0)
+    # Add output node
+    graph.add_node("output", node_type=NodeType.UNEMBEDDING)
+
+    # Scan each layer
+    layer_impacts = {}
+    for i, layer_name in enumerate(layers):
+        if isinstance(layer_name, tuple):
+            layer_name = layer_name[0]
+
+        node_id = f"layer.{i}.{layer_name}"
+
+        # Determine node type
+        lower_name = str(layer_name).lower()
+        if "attn" in lower_name or "attention" in lower_name:
+            node_type = NodeType.ATTENTION_HEAD
+        elif "mlp" in lower_name or "ff" in lower_name:
+            node_type = NodeType.MLP_LAYER
+        else:
+            node_type = NodeType.RESIDUAL_STREAM
+
+        graph.add_node(node_id, node_type=node_type, layer=i)
+
+        # Try to measure impact of ablating this layer
+        try:
+            module = model.get_layer_module(layer_name)
+
+            # Create a zeroing/ablation hook
+            original_output = [None]
+
+            def make_ablation_hook(strat):
+                def hook(module, input, output):
+                    if strat == "zero":
+                        if isinstance(output, tuple):
+                            return tuple(torch.zeros_like(o) if isinstance(o, torch.Tensor) else o for o in output)
+                        return torch.zeros_like(output)
+                    elif strat == "random":
+                        if isinstance(output, tuple):
+                            return tuple(torch.randn_like(o) if isinstance(o, torch.Tensor) else o for o in output)
+                        return torch.randn_like(output)
+                    return output
+                return hook
+
+            handle = module.register_forward_hook(make_ablation_hook(strategy))
+            with torch.no_grad():
+                ablated_output = wrapper_model(clean_input)
+                if hasattr(ablated_output, "logits"):
+                    ablated_metric = metric_fn(ablated_output.logits)
+                elif hasattr(ablated_output, "last_hidden_state"):
+                    ablated_metric = metric_fn(ablated_output.last_hidden_state)
+                else:
+                    ablated_metric = metric_fn(ablated_output)
+            handle.remove()
+
+            ablated_val = float(ablated_metric) if isinstance(ablated_metric, torch.Tensor) else float(ablated_metric)
+            impact = abs(baseline_val - ablated_val)
+            layer_impacts[node_id] = impact
+
+            # Add edges with impact as weight
+            graph.add_edge("input", node_id, weight=impact, edge_type=EdgeType.INFERRED)
+            graph.add_edge(node_id, "output", weight=impact, edge_type=EdgeType.INFERRED)
+
+        except (ValueError, AttributeError, RuntimeError):
+            # Layer couldn't be hooked — still add edges with zero weight
+            graph.add_edge("input", node_id, weight=0.0, edge_type=EdgeType.INFERRED)
+            graph.add_edge(node_id, "output", weight=0.0, edge_type=EdgeType.INFERRED)
+
+    return graph
+
+
+def run_logit_lens(
+    model_name: str,
+    text: str,
+    top_k: int = 5,
+    model: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """
+    Run logit lens analysis on a model.
+
+    Projects each layer's hidden states through the unembedding matrix to see
+    what tokens the model is "thinking about" at each layer.
+
+    Args:
+        model_name: HuggingFace model name (e.g., "gpt2").
+        text: Input text to analyze.
+        top_k: Number of top predicted tokens to return per position.
+        model: Optional pre-loaded ModelWrapper.
+
+    Returns:
+        Dict with keys:
+            - "tokens": List of input token strings
+            - "logit_lens_data": np.ndarray of shape (n_layers, seq_len)
+                with probability of correct next token at each layer
+            - "top_k_tokens": List[List[List[str]]] — top-k token predictions
+                per layer per position
+            - "probabilities": np.ndarray of shape (n_layers, seq_len, vocab_size)
+    """
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    hf_model = AutoModelForCausalLM.from_pretrained(model_name, output_hidden_states=True)
+    hf_model.eval()
+
+    # Tokenize
+    inputs = tokenizer(text, return_tensors="pt")
+    input_ids = inputs["input_ids"]
+    tokens = [tokenizer.decode(t) for t in input_ids[0]]
+
+    # Forward pass with hidden states
+    with torch.no_grad():
+        outputs = hf_model(**inputs)
+
+    hidden_states = outputs.hidden_states  # tuple of (batch, seq_len, hidden)
+    lm_head = hf_model.lm_head if hasattr(hf_model, "lm_head") else None
+
+    if lm_head is None:
+        raise ValueError(f"Model {model_name} does not have an lm_head for logit lens")
+
+    n_layers = len(hidden_states) - 1  # exclude embedding layer
+    seq_len = input_ids.shape[1]
+
+    logit_lens_data = np.zeros((n_layers, seq_len))
+    top_k_tokens_all = []
+    all_probs = []
+
+    for layer_idx in range(1, len(hidden_states)):  # skip embedding layer
+        hidden = hidden_states[layer_idx]
+
+        with torch.no_grad():
+            logits = lm_head(hidden)  # (batch, seq_len, vocab_size)
+            probs = torch.softmax(logits[0], dim=-1)  # (seq_len, vocab_size)
+
+        all_probs.append(_to_numpy(probs))
+
+        # For each position, get probability of the "correct" next token
+        layer_top_k = []
+        for pos in range(seq_len):
+            # Top-k tokens at this position
+            top_vals, top_ids = torch.topk(probs[pos], top_k)
+            top_tokens = [tokenizer.decode(tid.item()) for tid in top_ids]
+            layer_top_k.append(top_tokens)
+
+            # Correct next token probability
+            if pos < seq_len - 1:
+                next_token_id = input_ids[0, pos + 1].item()
+                logit_lens_data[layer_idx - 1, pos] = float(probs[pos, next_token_id])
+            else:
+                logit_lens_data[layer_idx - 1, pos] = 0.0
+
+        top_k_tokens_all.append(layer_top_k)
+
+    return {
+        "tokens": tokens,
+        "logit_lens_data": logit_lens_data,
+        "top_k_tokens": top_k_tokens_all,
+        "probabilities": np.stack(all_probs, axis=0),
+    }

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,356 @@
+"""
+Tests for the pipeline glue layer.
+
+Uses mocks for heavy model loading to keep tests fast and portable.
+"""
+
+import numpy as np
+import pytest
+import torch
+from unittest.mock import MagicMock, patch, PropertyMock
+
+from glassboxllms.pipeline import (
+    _to_torch,
+    _to_numpy,
+    extract_activations,
+    train_sae_on_model,
+    train_probe_on_model,
+    discover_circuit,
+)
+from glassboxllms.features import SparseAutoencoder, SAETrainer, FeatureSet
+from glassboxllms.analysis.circuits.graph import CircuitGraph
+from glassboxllms.analysis.circuits.node import NodeType
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+HIDDEN_DIM = 64
+SEQ_LEN = 8
+BATCH_SIZE = 4
+
+
+def _fake_activations(n_texts, seq_len=SEQ_LEN, hidden_dim=HIDDEN_DIM):
+    """Return fake activation tensor of shape (n_texts, seq_len, hidden_dim)."""
+    return torch.randn(n_texts, seq_len, hidden_dim)
+
+
+def _mock_model(layer_names=None):
+    """Create a mock ModelWrapper with sensible defaults."""
+    if layer_names is None:
+        layer_names = [f"layer.{i}" for i in range(4)]
+
+    model = MagicMock()
+    model.layer_names = layer_names
+    model.model = MagicMock()
+
+    def fake_get_activations(texts, layers, return_type="numpy"):
+        n = len(texts) if isinstance(texts, list) else 1
+        acts = {}
+        for layer in layers:
+            t = torch.randn(n, SEQ_LEN, HIDDEN_DIM)
+            if return_type == "numpy":
+                acts[layer] = t.numpy()
+            else:
+                acts[layer] = t
+        return acts
+
+    model.get_activations = MagicMock(side_effect=fake_get_activations)
+
+    # Mock tokenizer
+    model.tokenizer = MagicMock()
+    model.tokenizer.return_value = {
+        "input_ids": torch.randint(0, 1000, (1, SEQ_LEN)),
+        "attention_mask": torch.ones(1, SEQ_LEN, dtype=torch.long),
+    }
+
+    # Mock get_layer_module
+    def fake_get_layer_module(layer_name):
+        module = MagicMock()
+        module.register_forward_hook = MagicMock(return_value=MagicMock())
+        return module
+
+    model.get_layer_module = MagicMock(side_effect=fake_get_layer_module)
+
+    return model
+
+
+# ---------------------------------------------------------------------------
+# Type conversion tests
+# ---------------------------------------------------------------------------
+
+
+class TestTypeConversions:
+    def test_numpy_to_torch(self):
+        arr = np.random.randn(3, 4).astype(np.float32)
+        tensor = _to_torch(arr)
+        assert isinstance(tensor, torch.Tensor)
+        assert tensor.shape == (3, 4)
+        np.testing.assert_allclose(tensor.numpy(), arr, atol=1e-6)
+
+    def test_torch_to_torch(self):
+        tensor = torch.randn(3, 4)
+        result = _to_torch(tensor)
+        assert isinstance(result, torch.Tensor)
+        assert result.dtype == torch.float32
+
+    def test_torch_to_numpy(self):
+        tensor = torch.randn(3, 4)
+        arr = _to_numpy(tensor)
+        assert isinstance(arr, np.ndarray)
+        assert arr.shape == (3, 4)
+
+    def test_numpy_to_numpy(self):
+        arr = np.random.randn(3, 4)
+        result = _to_numpy(arr)
+        assert isinstance(result, np.ndarray)
+
+
+# ---------------------------------------------------------------------------
+# extract_activations tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractActivations:
+    def test_returns_torch_by_default(self):
+        model = _mock_model()
+        result = extract_activations(
+            "gpt2", ["hello"], ["layer.0"], return_type="torch", model=model
+        )
+        assert "layer.0" in result
+        assert isinstance(result["layer.0"], torch.Tensor)
+
+    def test_returns_numpy(self):
+        model = _mock_model()
+        result = extract_activations(
+            "gpt2", ["hello"], ["layer.0"], return_type="numpy", model=model
+        )
+        assert isinstance(result["layer.0"], np.ndarray)
+
+    def test_multiple_layers(self):
+        model = _mock_model()
+        layers = ["layer.0", "layer.1", "layer.2"]
+        result = extract_activations(
+            "gpt2", ["hello", "world"], layers, return_type="torch", model=model
+        )
+        assert len(result) == 3
+        for layer in layers:
+            assert layer in result
+            assert result[layer].shape[0] == 2  # batch size
+
+
+# ---------------------------------------------------------------------------
+# train_sae_on_model tests
+# ---------------------------------------------------------------------------
+
+
+class TestTrainSaeOnModel:
+    @patch("glassboxllms.pipeline._load_model")
+    def test_returns_sae_and_feature_set(self, mock_load):
+        model = _mock_model()
+        mock_load.return_value = model
+
+        sae, feature_set = train_sae_on_model(
+            "gpt2",
+            texts=["text1", "text2", "text3"],
+            layer="layer.0",
+            feature_dim=128,
+            k=16,
+            n_epochs=1,
+            batch_size=8,
+        )
+
+        assert isinstance(sae, SparseAutoencoder)
+        assert isinstance(feature_set, FeatureSet)
+        assert sae.feature_dim == 128
+        assert sae.k == 16
+        assert len(feature_set) == 128
+
+    @patch("glassboxllms.pipeline._load_model")
+    def test_feature_set_has_metadata(self, mock_load):
+        model = _mock_model()
+        mock_load.return_value = model
+
+        _, feature_set = train_sae_on_model(
+            "gpt2",
+            texts=["text1", "text2"],
+            layer="layer.0",
+            feature_dim=64,
+            k=8,
+            n_epochs=1,
+        )
+
+        assert feature_set.config["model_name"] == "gpt2"
+        assert feature_set.config["layer"] == "layer.0"
+
+    @patch("glassboxllms.pipeline._load_model")
+    def test_passes_model_through(self, mock_load):
+        model = _mock_model()
+
+        sae, _ = train_sae_on_model(
+            "gpt2",
+            texts=["text1"],
+            layer="layer.0",
+            feature_dim=64,
+            k=8,
+            n_epochs=1,
+            model=model,
+        )
+
+        # _load_model should NOT be called when model is passed
+        mock_load.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# train_probe_on_model tests
+# ---------------------------------------------------------------------------
+
+
+class TestTrainProbeOnModel:
+    @patch("glassboxllms.pipeline._load_model")
+    def test_returns_probe_and_direction(self, mock_load):
+        model = _mock_model()
+        mock_load.return_value = model
+
+        probe, direction = train_probe_on_model(
+            "gpt2",
+            positive_texts=["good", "great", "excellent"],
+            negative_texts=["bad", "terrible", "awful"],
+            layer="layer.0",
+        )
+
+        assert probe.is_fitted
+        assert isinstance(direction, np.ndarray)
+        assert direction.shape == (HIDDEN_DIM,)
+
+    @patch("glassboxllms.pipeline._load_model")
+    def test_probe_type_cav(self, mock_load):
+        model = _mock_model()
+        mock_load.return_value = model
+
+        probe, direction = train_probe_on_model(
+            "gpt2",
+            positive_texts=["good", "great"],
+            negative_texts=["bad", "awful"],
+            layer="layer.0",
+            probe_type="cav",
+        )
+
+        assert probe.is_fitted
+        assert probe.model_type == "cav"
+
+
+# ---------------------------------------------------------------------------
+# discover_circuit tests
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverCircuit:
+    @patch("glassboxllms.pipeline._load_model")
+    def test_returns_circuit_graph(self, mock_load):
+        model = _mock_model(layer_names=["layer.0", "layer.1"])
+        # Make model.model callable and return something with last_hidden_state
+        output_mock = MagicMock()
+        output_mock.last_hidden_state = torch.randn(1, SEQ_LEN, HIDDEN_DIM)
+        model.model.return_value = output_mock
+        mock_load.return_value = model
+
+        def metric(output):
+            return output[0, -1].norm()
+
+        graph = discover_circuit(
+            "gpt2",
+            text="hello world",
+            metric_fn=metric,
+            layers=["layer.0", "layer.1"],
+        )
+
+        assert isinstance(graph, CircuitGraph)
+        assert graph.model == "gpt2"
+        assert graph.has_node("input")
+        assert graph.has_node("output")
+
+    @patch("glassboxllms.pipeline._load_model")
+    def test_graph_has_layer_nodes(self, mock_load):
+        layers = ["layer.0", "attn.1", "mlp.2"]
+        model = _mock_model(layer_names=layers)
+        output_mock = MagicMock()
+        output_mock.last_hidden_state = torch.randn(1, SEQ_LEN, HIDDEN_DIM)
+        model.model.return_value = output_mock
+        mock_load.return_value = model
+
+        def metric(output):
+            return output[0, -1].norm()
+
+        graph = discover_circuit(
+            "gpt2",
+            text="test",
+            metric_fn=metric,
+            layers=layers,
+        )
+
+        # Should have input + output + 3 layer nodes = 5
+        assert len(graph) == 5
+
+    @patch("glassboxllms.pipeline._load_model")
+    def test_graph_metadata(self, mock_load):
+        model = _mock_model(layer_names=["layer.0"])
+        output_mock = MagicMock()
+        output_mock.last_hidden_state = torch.randn(1, SEQ_LEN, HIDDEN_DIM)
+        model.model.return_value = output_mock
+        mock_load.return_value = model
+
+        graph = discover_circuit(
+            "gpt2",
+            text="test input",
+            metric_fn=lambda x: x[0, -1].norm(),
+            layers=["layer.0"],
+            strategy="zero",
+        )
+
+        assert graph.metadata["strategy"] == "zero"
+        assert graph.metadata["text"] == "test input"
+        assert "baseline_metric" in graph.metadata
+
+
+# ---------------------------------------------------------------------------
+# SAETrainer.get_feature_set tests
+# ---------------------------------------------------------------------------
+
+
+class TestTrainerGetFeatureSet:
+    def test_get_feature_set_basic(self):
+        input_dim = 32
+        feature_dim = 64
+        sae = SparseAutoencoder(input_dim=input_dim, feature_dim=feature_dim, k=8)
+
+        data = torch.randn(100, input_dim)
+        dataset = torch.utils.data.TensorDataset(data)
+        dataloader = torch.utils.data.DataLoader(dataset, batch_size=16)
+
+        trainer = SAETrainer(sae, dataloader)
+        trainer.train(n_epochs=1)
+
+        fs = trainer.get_feature_set(model_name="test-model", layer="layer.5")
+
+        assert isinstance(fs, FeatureSet)
+        assert len(fs) == feature_dim
+        assert fs.config["model_name"] == "test-model"
+        assert fs.config["layer"] == "layer.5"
+        assert fs.W_dec.shape == (feature_dim, input_dim)
+        assert fs.W_enc.shape == (input_dim, feature_dim)
+
+    def test_get_feature_set_has_stats(self):
+        sae = SparseAutoencoder(input_dim=16, feature_dim=32, k=4)
+        data = torch.randn(50, 16)
+        dataloader = torch.utils.data.DataLoader(
+            torch.utils.data.TensorDataset(data), batch_size=16
+        )
+
+        trainer = SAETrainer(sae, dataloader)
+        trainer.train(n_epochs=1)
+
+        fs = trainer.get_feature_set()
+        assert "final_explained_variance" in fs.stats
+        assert "final_mse" in fs.stats


### PR DESCRIPTION
## Summary

Closes #77

Adds a thin integration layer (`glassboxllms/pipeline.py`) that chains model → activations → SAE/probes → features → visualization, handling type conversions and boilerplate automatically. Users can go from model → results in a few lines.

- **`extract_activations()`** — wraps ModelWrapper with automatic torch/numpy return type handling
- **`train_sae_on_model()`** — model name + layer + texts → trained SAE + FeatureSet (handles activation extraction, DataLoader creation, geometric median init, training, and FeatureSet conversion)
- **`train_probe_on_model()`** — model + positive/negative examples → trained LinearProbe + direction vector
- **`discover_circuit()`** — model + text + metric → layer-by-layer ablation scan → populated CircuitGraph with impact-weighted edges
- **`run_logit_lens()`** — full logit lens analysis returning per-layer token predictions and probabilities
- **`SAETrainer.get_feature_set()`** — new method to convert a trained SAE's weights + stats into a FeatureSet object
- **`examples/full_pipeline_demo.py`** — end-to-end GPT-2 demo showing all pipeline functions
- **`tests/test_pipeline.py`** — 17 unit tests with mocked model loading (no GPU needed)

## Test plan

- [x] All 17 new tests pass (`pytest tests/test_pipeline.py -v`)
- [x] All existing tests still pass (243 passed, 2 pre-existing failures from missing `safetensors` dep)
- [ ] Manual test of `examples/full_pipeline_demo.py` with GPT-2 (requires `transformers` installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)